### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
 setting.py
+
+# Created by https://www.gitignore.io/api/laravel
+
+### Laravel ###
+/vendor
+node_modules/
+npm-debug.log
+
+# Laravel 4 specific
+bootstrap/compiled.php
+app/storage/
+
+# Laravel 5 & Lumen specific
+public/storage
+public/hot
+storage/*.key
+.env.*.php
+.env.php
+.env
+Homestead.yaml
+Homestead.json
+
+# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
+.rocketeer/
+
+
+# End of https://www.gitignore.io/api/laravel


### PR DESCRIPTION
#¿Qué ha cambiado?
Agregamos al git ignore soporte para Laravel.
- [ ] Frontend
- [ ] Backend
- [x] Configuración del server.

# ¿Cómo puedo probar los cambios?
Los archivos y la carpeta no vendor ya no se suben al repositorio remoto. Ver el archivo .gitignore completo para más detalles.
